### PR TITLE
Update plan-patch docs and add reference to the `target` variable

### DIFF
--- a/docs/plan-patch.md
+++ b/docs/plan-patch.md
@@ -17,7 +17,7 @@ Instead of creating a new comment, you can update existing comment. This is usef
 The option `-patch` has been added to `tfcmt plan` command.
 
 ```console
-tfcmt plan -patch -- terraform plan -no-color
+$ tfcmt plan -patch -- terraform plan -no-color
 ```
 
 And the configuration option `plan_patch` has been added.

--- a/docs/plan-patch.md
+++ b/docs/plan-patch.md
@@ -40,7 +40,7 @@ By patching the comment instead of creating a new comment, you can keep the pull
 
 ### Using `-patch` with monorepos containing multiple root modules (tfstates)
 
-You can specify `target` variable to tell tfcmt which comments should update:
+You can specify the `target` variable to instruct tfcmt which comments should be updated:
 
 ```console
 $ cd /path/to/root-modules/dev

--- a/docs/plan-patch.md
+++ b/docs/plan-patch.md
@@ -38,7 +38,7 @@ $ tfcmt plan -patch=false -- terraform plan -no-color
 
 By patching the comment instead of creating a new comment, you can keep the pull request comments clean.
 
-### Using `-patch` with monorepo which contains multiple root modules (tfstate)
+### Using `-patch` with monorepos containing multiple root modules (tfstates)
 
 You can specify `target` variable to tell tfcmt which comments should update:
 

--- a/docs/plan-patch.md
+++ b/docs/plan-patch.md
@@ -38,6 +38,20 @@ $ tfcmt plan -patch=false -- terraform plan -no-color
 
 By patching the comment instead of creating a new comment, you can keep the pull request comments clean.
 
+### Using `-patch` with monorepo which contains multiple root modules (tfstate)
+
+You can specify `target` variable to tell tfcmt which comments should update:
+
+```console
+$ cd /path/to/root-modules/dev
+$ tfcmt -var 'target:dev' plan -patch -- terraform plan -no-color
+
+$ cd /path/to/root-modules/prd
+$ tfcmt -var 'target:prd' plan -patch -- terraform plan -no-color
+```
+
+See also [Monorepo support: target variable](getting-started#monorepo-support-target-variable).
+
 ### Trouble shooting
 
 If the comment isn't patched expectedly, please set `-log-level=debug`.


### PR DESCRIPTION
## Check List

<!-- Please check the list. Please don't remove the check list. -->

- [x] Read [OSS Contribution Guide](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/README.md)
    - I have read the guide and understand that I should open an issue before creating a PR; however, since this is only a documentation update, I skipped opening an issue.
- [x] [All commits are signed](https://github.com/suzuki-shunsuke/oss-contribution-guide/blob/main/docs/commit-signing.md)
- [x] [Avoid force push](https://github.com/suzuki-shunsuke/oss-contribution-guide?tab=readme-ov-file#dont-do-force-pushes-after-opening-pull-requests)
- [x] Do only one thing in one Pull Request

<!-- Please write the description here -->

## Description

I noticed that some users overlooked the fact that the `-patch` option can be used in combination with `-var target:foo` (for example, https://github.com/suzuki-shunsuke/tfcmt/issues/415 and https://github.com/suzuki-shunsuke/tfcmt/issues/1373). I was one of those users.

To address this issue, I have added a description of this use case in `plan-patch.md`.